### PR TITLE
consumer에서 proguard로 빌드하면 크래시가 나는 이슈 픽스

### DIFF
--- a/pagecall/build.gradle
+++ b/pagecall/build.gradle
@@ -14,7 +14,7 @@ android {
         consumerProguardFiles "consumer-rules.pro"
 
         versionCode 0
-        versionName "0.0.14" // Update `version` field of PagecallWebView as you change this
+        versionName "0.0.15" // Update `version` field of PagecallWebView as you change this
     }
 
     buildTypes {
@@ -44,7 +44,7 @@ ext {
     GITHUB_USER = "pagecall"
     GITHUB_REPO = "pagecall-android-sdk"
     GITHUB_PKG_NAME = "pagecall-android-sdk"
-    GITHUB_PKG_VERSION = "0.0.14"
+    GITHUB_PKG_VERSION = "0.0.15"
 }
 
 publishing {

--- a/pagecall/consumer-rules.pro
+++ b/pagecall/consumer-rules.pro
@@ -1,0 +1,2 @@
+-keep class org.webrtc.**  { *; }
+-keep class org.mediasoup.** { *; }

--- a/pagecall/src/main/java/com/pagecall/PagecallWebView.java
+++ b/pagecall/src/main/java/com/pagecall/PagecallWebView.java
@@ -18,7 +18,7 @@ import java.util.function.Consumer;
 
 // TODO: package private
 public class PagecallWebView extends WebView {
-    final static String version = "0.0.14";
+    final static String version = "0.0.15";
     private final static String[] defaultPagecallUrls = {"app.pagecall", "demo.pagecall", "192.168"};
     private final static String jsInterfaceName = "pagecallAndroidBridge";
     private HashMap<String, Consumer<String>> subscribers = new HashMap<>();

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -17,8 +17,9 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.debug
         }
     }
     compileOptions {

--- a/sample/src/main/java/com/pagecall/sample/MainActivity.java
+++ b/sample/src/main/java/com/pagecall/sample/MainActivity.java
@@ -52,7 +52,7 @@ public class MainActivity extends AppCompatActivity {
                 webView.setLayoutParams(new ViewGroup.LayoutParams(
                         ViewGroup.LayoutParams.MATCH_PARENT,
                         ViewGroup.LayoutParams.MATCH_PARENT));
-                webView.loadUrl("https://demo.pagecall.net/join/six-canvas/230321abcjurung?build=latest&chime=0");
+                webView.loadUrl("https://demo.pagecall.net/join/six-canvas/230531abcjurung?build=latest&chime=0");
                 webView.listenMessage(message -> {
                     Log.d("Ryan", "message: " + message);
                 });


### PR DESCRIPTION
consumer가 proguard를 켜고 빌드하면 mediasoup 및 webrtc 모듈이 트리셰이킹되는 것이 원인이었습니다.