### PR TITLE
XML layout inflation을 지원합니다

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ dependencies {
 
 ## Usage
 
+#### Activity (Java)
+
 1. In your Android project, import the PagecallWebView class:
 ```java
 import com.pagecall.PagecallWebView;
@@ -60,6 +62,15 @@ webView.loadUrl("https://app.pagecall.com/meet?room_id={room_id}&access_token={a
 ```
 
 The current version of this SDK does not detect when a user denies permissions. Please ensure that permissions are granted before entering a room.
+
+#### Layout (XML)
+
+```xml
+<com.pagecall.PagecallWebView
+    android:id="@+id/webview"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />
+```
 
 ## Support
 

--- a/pagecall/build.gradle
+++ b/pagecall/build.gradle
@@ -14,7 +14,7 @@ android {
         consumerProguardFiles "consumer-rules.pro"
 
         versionCode 0
-        versionName "0.0.16" // Update `version` field of PagecallWebView as you change this
+        versionName "0.0.17" // Update `version` field of PagecallWebView as you change this
     }
 
     buildTypes {
@@ -44,7 +44,7 @@ ext {
     GITHUB_USER = "pagecall"
     GITHUB_REPO = "pagecall-android-sdk"
     GITHUB_PKG_NAME = "pagecall-android-sdk"
-    GITHUB_PKG_VERSION = "0.0.16"
+    GITHUB_PKG_VERSION = "0.0.17"
 }
 
 publishing {

--- a/pagecall/src/main/java/com/pagecall/PagecallWebView.java
+++ b/pagecall/src/main/java/com/pagecall/PagecallWebView.java
@@ -1,8 +1,8 @@
 package com.pagecall;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.AssetManager;
+import android.util.AttributeSet;
 import android.webkit.PermissionRequest;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
@@ -26,19 +26,20 @@ public class PagecallWebView extends WebView {
     private String[] pagecallUrls = null;
     private NativeBridge nativeBridge = null;
 
-    public PagecallWebView(Context context, String[] pagecallUrls) {
-        this(context);
-        this.pagecallUrls = pagecallUrls;
+    public PagecallWebView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init(context);
     }
 
-    @SuppressLint("SetJavaScriptEnabled")
     public PagecallWebView(Context context) {
         super(context);
+        init(context);
+    }
 
+    protected void init(Context context) {
         if (this.pagecallUrls == null) {
             pagecallUrls = defaultPagecallUrls;
         }
-
         this.getSettings().setJavaScriptEnabled(true);
         this.getSettings().setDomStorageEnabled(true);
         String userAgent = this.getSettings().getUserAgentString();
@@ -63,6 +64,7 @@ public class PagecallWebView extends WebView {
             }
         });
     }
+
     private boolean isUrlContainsPagecallUrl(String url) {
         for (String pagecallUrl : pagecallUrls) {
             if (url.contains(pagecallUrl)) {


### PR DESCRIPTION
- XML layout inflation을 지원하기 위해 `PagecallWebView`의 constructor를 오버로딩합니다.
- 버전을 0.0.17으로 올립니다.

테스트 항목
- `webView = findViewById(R.id.webview);`로 액세스하여 똑같이 제어가능한가
- 페이지콜 입장, 좀비세션, 음성에는 문제없는가