### PR TITLE
fix: set volume in 0~1

### DIFF
--- a/pagecall/src/main/java/com/pagecall/AudioRecordManager.java
+++ b/pagecall/src/main/java/com/pagecall/AudioRecordManager.java
@@ -76,7 +76,8 @@ class AudioRecordManager {
      */
     static double getMicrophoneVolume(@NonNull Context context) {
         double amplitude = getMicrophoneAmplitude(context);
-        return (amplitude - AMPLITUDE_IDLE) / AMPLITUDE_MAX;
+        double volume = (amplitude - AMPLITUDE_IDLE) / AMPLITUDE_MAX;
+        return Math.max(0, Math.min(1, volume));
     }
 
     /**


### PR DESCRIPTION
# Changes
- 코어앱에 전달하는 volume 값의 range가 0~1 사이에 있도록 합니다.

# Ref
https://github.com/pplink/pagecall/pull/3395
https://github.com/pagecall/pagecall-ios-sdk/blob/main/Sources/PagecallSDK/VolumeRecorder.swift#L27