### PR TITLE
fix: prevent verbose audio device list on MI

### DIFF
--- a/pagecall/src/main/java/com/pagecall/MediaDeviceInfo.java
+++ b/pagecall/src/main/java/com/pagecall/MediaDeviceInfo.java
@@ -42,6 +42,14 @@ class MediaDeviceInfo {
         return mediaDeviceInfoList;
     }
 
+    public static MediaDeviceInfo[] pickOneInput(MediaDeviceInfo[] originalDeviceList) {
+        for (MediaDeviceInfo deviceInfo : originalDeviceList) {
+            if ("audioinput".equals(deviceInfo.getKind().toString())) {
+                return new MediaDeviceInfo[]{deviceInfo};
+            }
+        }
+        return new MediaDeviceInfo[]{};
+    }
     @NonNull
     public static JSONArray convertToJSONArray(@NonNull MediaDeviceInfo[] mediaDeviceInfoList) throws JSONException {
         String json = GSON.toJson(mediaDeviceInfoList);

--- a/pagecall/src/main/java/com/pagecall/NativeBridge.java
+++ b/pagecall/src/main/java/com/pagecall/NativeBridge.java
@@ -257,7 +257,16 @@ class NativeBridge {
                         System.arraycopy(audioOutputDevices, 0, audioDevices, audioInputDevices.length, audioOutputDevices.length);
 
                         MediaDeviceInfo[] deviceList = MediaDeviceInfo.convertToMediaDeviceInfo(audioDevices);
-                        respondArray.accept(null, MediaDeviceInfo.convertToJSONArray(deviceList));
+
+                        /**
+                         * 코어앱에서 불필요하게 디바이스를 많이 보여주지않기 위해 input 중 하나만 넘겨줌.
+                         * SET_AUDIO_DEVICE를 하지 않기 때문에 괜찮다.
+                         * TODO: SET_AUDIO_DEVICE를 하게 되면 알맞게 전달해야함.
+                         */
+                        MediaDeviceInfo[] pickedDeviceList = MediaDeviceInfo.pickOneInput(deviceList);
+
+                        respondArray.accept(null, MediaDeviceInfo.convertToJSONArray(pickedDeviceList));
+
                     } else {
                         respondEmpty.accept(new PagecallError("Missing audioManager"));
                     }


### PR DESCRIPTION
# Changes
- 아래 문제를 해결합니다.
- 문제
  - 코어앱 장치 리스트에 7개 가량의 오디오 장치가 표시됨. 오디오 장치를 변경해도 아무런 효과가 없음
    - 효과가 없는 것은 의도된 바입니다.
  - 이는 아래와 같은 혼란을 유발합니다.
    - 음성 이슈 발생시 무의미하게 기기를 교체하려는 시도를 하면서 시간을 허비하게 됨
    - 모종의 의도로 오디오 장치 교체 시도하는데 오디오 장치 교체가 되지 않아서 문의 인입