### PR TITLE
Add `onError()` listener method in PagecallWebView

### DIFF
--- a/pagecall/src/main/java/com/pagecall/PagecallWebView.java
+++ b/pagecall/src/main/java/com/pagecall/PagecallWebView.java
@@ -8,6 +8,8 @@ import android.net.Uri;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
 import android.webkit.WebChromeClient;
+import android.webkit.WebResourceError;
+import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
@@ -32,6 +34,7 @@ final public class PagecallWebView extends WebView {
         void onLoaded();
         void onMessage(String message);
         void onTerminated(TerminationReason reason);
+        void onError(WebResourceError error);
     }
 
     public enum PagecallMode {
@@ -233,10 +236,18 @@ final public class PagecallWebView extends WebView {
         this.addJavascriptInterface(nativeBridge, jsInterfaceName);
 
         super.setWebViewClient(new WebViewClient() {
+            @Override
             public void onPageFinished(WebView view, String url) {
                 if (isUrlContainsPagecallUrl(url)) {
                     String jsCode = getNativeJS();
                     view.evaluateJavascript(jsCode, null);
+                }
+            }
+
+            @Override
+            public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
+                if (listener != null) {
+                    listener.onError(error);
                 }
             }
         });

--- a/sample/src/main/java/com/pagecall/sample/PagecallFragment.java
+++ b/sample/src/main/java/com/pagecall/sample/PagecallFragment.java
@@ -13,6 +13,7 @@ import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.WebResourceError;
 import android.widget.FrameLayout;
 
 import androidx.appcompat.widget.Toolbar;
@@ -119,5 +120,10 @@ public class PagecallFragment extends Fragment implements PagecallWebView.Listen
         if (reason == TerminationReason.OTHER) {
             Log.d("SampleApp", "Terminated with other reason (" + reason.getOtherReason() + ")");
         }
+    }
+
+    @Override
+    public void onError(WebResourceError error) {
+        Log.d("SampleApp", "Error occurred " + error.getDescription());
     }
 }


### PR DESCRIPTION
# Changes
Add `onError()` listener method to enable consumer app to handle unrecoverable errors.

# Tests
Load an invalid url on purpose and confirmed that `onError()` is invoked.