### PR TITLE
fix: call Pagecall.terminate before destroying webview

### DIFF
--- a/pagecall/src/main/java/com/pagecall/PagecallWebView.java
+++ b/pagecall/src/main/java/com/pagecall/PagecallWebView.java
@@ -349,6 +349,11 @@ final public class PagecallWebView extends WebView {
     }
 
     @Override
+    public void destroy() {
+        evaluateJavascript("Pagecall.terminate()", value -> super.destroy());
+    }
+
+    @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
         destroyBridge();


### PR DESCRIPTION
Call Pagecall.terminate before destroying webview to disconnect a session properly.