### PR TITLE
fix: use bluetooth on MI

### DIFF
--- a/pagecall/src/main/java/com/pagecall/PagecallWebView.java
+++ b/pagecall/src/main/java/com/pagecall/PagecallWebView.java
@@ -217,6 +217,15 @@ final public class PagecallWebView extends WebView {
                             audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
                         } else {
                             // MI
+                            try {
+                                AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+                                audioManager.setBluetoothScoOn(true);
+                                audioManager.startBluetoothSco();
+                                // 1. Should it be stopped later?
+                                // 2. Should it be called on Chime?
+                            } catch (Exception e) {
+                                e.printStackTrace();
+                            }
                         }
                     }));
                     break;


### PR DESCRIPTION
Enable audio output to a Bluetooth audio device when using MI and a Bluetooth audio device is connected. If no Bluetooth audio device is connected, audio will be output through the device's own audio system or wired devices, as usual.