### PR TITLE
refactor: PagecallWebView accepts only ActivityContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The `credentials` field is necessary for this purpose. The required permission i
 2. Add the dependency to your app's build.gradle file:
 ```gradle
 dependencies {
-    implementation 'com.pagecall:pagecall-android-sdk:0.0.33' // Recommended to use the latest
+    implementation 'com.pagecall:pagecall-android-sdk:0.0.34' // Recommended to use the latest
 }
 ```
 3. Sync your project with the Gradle files.

--- a/pagecall/build.gradle
+++ b/pagecall/build.gradle
@@ -14,7 +14,7 @@ android {
         consumerProguardFiles "consumer-rules.pro"
 
         versionCode 0
-        versionName "0.0.33" // Update `version` field of PagecallWebView as you change this
+        versionName "0.0.34" // Update `version` field of PagecallWebView as you change this
     }
 
     buildTypes {
@@ -44,7 +44,7 @@ ext {
     GITHUB_USER = "pagecall"
     GITHUB_REPO = "pagecall-android-sdk"
     GITHUB_PKG_NAME = "pagecall-android-sdk"
-    GITHUB_PKG_VERSION = "0.0.33"
+    GITHUB_PKG_VERSION = "0.0.34"
 }
 
 publishing {

--- a/pagecall/src/main/java/com/pagecall/PagecallWebView.java
+++ b/pagecall/src/main/java/com/pagecall/PagecallWebView.java
@@ -1,5 +1,6 @@
 package com.pagecall;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.AssetManager;
@@ -187,6 +188,10 @@ final public class PagecallWebView extends WebView {
     private PagecallWebChromeClient webChromeClient;
 
     protected void init(Context context) {
+        // Check if the context is ActivityContext
+        if (!(context instanceof Activity)) {
+            throw new IllegalArgumentException("Provided context is not an Activity context.");
+        }
         if (this.pagecallUrls == null) {
             pagecallUrls = defaultPagecallUrls;
         }

--- a/pagecall/src/main/java/com/pagecall/PagecallWebView.java
+++ b/pagecall/src/main/java/com/pagecall/PagecallWebView.java
@@ -73,7 +73,7 @@ final public class PagecallWebView extends WebView {
 
     private Listener listener;
 
-    final static String version = "0.0.33";
+    final static String version = "0.0.34";
 
     private final static String[] defaultPagecallUrls = {"app.pagecall", "demo.pagecall", "192.168"};
     private final static String jsInterfaceName = "pagecallAndroidBridge";


### PR DESCRIPTION
### Changes
- Introduces a strict requirement for PagecallWebView to only accept ActivityContext due to prevent permission-related issues early on.

### Tests
in SampleApp,
- `new PagecallWebView(view.getContext().getApplicationContext())` makes the app crashes.
- `new PagecallWebView(view.getContext())` works correctly.