### PR TITLE
Fix crash releated to `releaseBuffer`

### DIFF
--- a/pagecall/src/main/java/com/pagecall/NativeBridge.java
+++ b/pagecall/src/main/java/com/pagecall/NativeBridge.java
@@ -304,7 +304,7 @@ class NativeBridge {
 
                 case REQUEST_AUDIO_VOLUME:
                     double volume = AudioRecordManager.getMicrophoneVolume(context);
-                    respondNumber.accept(null, volume);
+                    respondNumber.accept(null, volume < 0 ? 0 : volume);
                     return;
 
                 case PAUSE_AUDIO:


### PR DESCRIPTION
It addresses crashes occurring with messages like `releaseBuffer: mUnreleased out of range, !(stepCount:160 <= mUnreleased:0 <= mFrameCount:480), BufferSizeInFrames:480`.
Although the exact reproduction path has not been identified and a definitive fix cannot be guaranteed, this fix has not resulted in any crashes after dozens of attempts.