### PR TITLE
Bluetooth audio switching

### DIFF
--- a/pagecall/src/main/java/com/pagecall/NativeBridge.java
+++ b/pagecall/src/main/java/com/pagecall/NativeBridge.java
@@ -145,6 +145,10 @@ class NativeBridge {
         this.subscribers = subscribers;
     }
 
+    public void log(String name, String message) {
+        this.emitter.log(name, message);
+    }
+
     private JSONObject safeParseJSON(String json) {
         if (json == null || json.isEmpty()) {
             return new JSONObject();

--- a/pagecall/src/main/java/com/pagecall/WebViewEmitter.java
+++ b/pagecall/src/main/java/com/pagecall/WebViewEmitter.java
@@ -124,7 +124,6 @@ class WebViewEmitter {
     }
 
     public void error(String name, String message) {
-        System.out.println("errorLog " + name + " " + message);
         JSONObject json = new JSONObject();
         try {
             json.put("name", name);
@@ -137,14 +136,15 @@ class WebViewEmitter {
     }
 
     public void log(String name, String message) {
-        NativeBridgeErrorEvent errorEvent = new NativeBridgeErrorEvent(name, message);
         JSONObject json = new JSONObject();
         try {
-            json.put("name", errorEvent.getName());
-            json.put("name", errorEvent.getName());
+            json.put("name", name);
+            json.put("message", message);
         } catch (JSONException e) {
+            e.printStackTrace();
             return;
         }
+        emit(NativeBridgeEvent.LOG, json);
     }
 
     public void runScript(final String script, Consumer<String> callback) {


### PR DESCRIPTION
- Automatically switch audio routing when Bluetooth earphones connect or disconnect.
- Propagate the name of the connected audio device to the web core.

## Tests conducted

- Successfully switched audio when connecting Galaxy Buds after initially joining with speakerphone.
- Successfully switched audio when disconnecting Galaxy Buds after joining while they were connected.

## Limitations

When taking the Galaxy Buds out of the ears, the audio switches to the speaker, but it does not switch back to the Galaxy Buds when they are worn again. If the Galaxy Buds are placed in the case and fully disconnected, then taken out again, the audio switches correctly. I have confirmed that `onActiveDeviceChanged` is called internally in the Android system (`Telecom:BluetoothRouteManager`), but have not yet found a way to subscribe to it.

## References

- https://developer.android.com/develop/connectivity/bluetooth/ble-audio/audio-manager