### PR TITLE
Catch possible error from `stop` of `AudioRecord`

### DIFF
--- a/pagecall/src/main/java/com/pagecall/AudioRecordManager.java
+++ b/pagecall/src/main/java/com/pagecall/AudioRecordManager.java
@@ -118,7 +118,13 @@ class AudioRecordManager {
 
     static void dispose() {
         if (audioRecord != null) {
-            audioRecord.stop();
+            if (audioRecord.getRecordingState() == AudioRecord.RECORDSTATE_RECORDING) {
+                try {
+                    audioRecord.stop();
+                } catch (IllegalStateException e) {
+                    Log.e("AudioRecordManager", e.getLocalizedMessage());
+                }
+            }
             audioRecord.release();
             audioRecord = null;
         }


### PR DESCRIPTION
As a case of `ApplicationNotResponding` error reported on the L121, add a guard and catch block.