### PR TITLE
USB headsets (0.0.46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The `credentials` field is necessary for this purpose. The required permission i
 2. Add the dependency to your app's build.gradle file:
 ```gradle
 dependencies {
-    implementation 'com.pagecall:pagecall-android-sdk:0.0.45' // Recommended to use the latest
+    implementation 'com.pagecall:pagecall-android-sdk:0.0.46' // Recommended to use the latest
 }
 ```
 3. Sync your project with the Gradle files.

--- a/pagecall/build.gradle
+++ b/pagecall/build.gradle
@@ -14,7 +14,7 @@ android {
         consumerProguardFiles "consumer-rules.pro"
 
         versionCode 0
-        versionName "0.0.45" // Update `version` field of PagecallWebView as you change this
+        versionName "0.0.46" // Update `version` field of PagecallWebView as you change this
     }
 
     buildTypes {
@@ -44,7 +44,7 @@ ext {
     GITHUB_USER = "pagecall"
     GITHUB_REPO = "pagecall-android-sdk"
     GITHUB_PKG_NAME = "pagecall-android-sdk"
-    GITHUB_PKG_VERSION = "0.0.45"
+    GITHUB_PKG_VERSION = "0.0.46"
 }
 
 publishing {

--- a/pagecall/src/main/java/com/pagecall/PagecallWebView.java
+++ b/pagecall/src/main/java/com/pagecall/PagecallWebView.java
@@ -199,6 +199,11 @@ final public class PagecallWebView extends WebView {
 
     private PagecallWebChromeClient webChromeClient;
 
+    private void sendChatForDebug(String message) {
+        String escapedMessage = message.replace("'", "\\'");
+        this.evaluateJavascriptWithLog("Pagecall.chat.sendMessage('" + escapedMessage + "');");
+    }
+
     private void updateCommunicationDevice() {
         AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
         List<AudioDeviceInfo> devices = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? audioManager.getAvailableCommunicationDevices() : Arrays.asList(audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS));

--- a/pagecall/src/main/java/com/pagecall/PagecallWebView.java
+++ b/pagecall/src/main/java/com/pagecall/PagecallWebView.java
@@ -226,39 +226,31 @@ final public class PagecallWebView extends WebView {
                 this.nativeBridge.log("deviceChange", "Bluetooth output detected: " + bluetoothDevice.getProductName());
             }
             return;
+        } else {
+            audioManager.stopBluetoothSco();
         }
 
-        // 2. Headphone (Including earpieces)
-        AudioDeviceInfo headphoneDevice = null;
+        // 2. External devices (Headsets, earpieces, ...)
+        AudioDeviceInfo externalDevice = null;
         for (AudioDeviceInfo deviceInfo : devices) {
-            if (deviceInfo.getType() == AudioDeviceInfo.TYPE_WIRED_HEADPHONES ||
-                    deviceInfo.getType() == AudioDeviceInfo.TYPE_WIRED_HEADSET ||
-                    deviceInfo.getType() == AudioDeviceInfo.TYPE_BUILTIN_EARPIECE) {
-                headphoneDevice = deviceInfo;
+            if (deviceInfo.getType() != AudioDeviceInfo.TYPE_BUILTIN_SPEAKER) {
+                externalDevice = deviceInfo;
                 break;
             }
         }
-        if (headphoneDevice != null) {
-            audioManager.stopBluetoothSco();
+        if (externalDevice != null) {
             audioManager.setSpeakerphoneOn(false);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                audioManager.setCommunicationDevice(headphoneDevice);
+                audioManager.setCommunicationDevice(externalDevice);
             }
             if (this.nativeBridge != null) {
-                this.nativeBridge.log("deviceChange", "Headphone output detected: " + headphoneDevice.getProductName());
+                this.nativeBridge.log("deviceChange", "External output detected: " + externalDevice.getProductName());
             }
             return;
         }
 
         // 3. Builtin
-        AudioDeviceInfo builtinDevice = null;
-        for (AudioDeviceInfo deviceInfo : devices) {
-            if (deviceInfo.getType() == AudioDeviceInfo.TYPE_BUILTIN_SPEAKER) {
-                builtinDevice = deviceInfo;
-                break;
-            }
-        }
-        audioManager.stopBluetoothSco();
+        AudioDeviceInfo builtinDevice = devices.get(0);
         audioManager.setSpeakerphoneOn(true);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             audioManager.clearCommunicationDevice();

--- a/pagecall/src/main/java/com/pagecall/PagecallWebView.java
+++ b/pagecall/src/main/java/com/pagecall/PagecallWebView.java
@@ -81,7 +81,7 @@ final public class PagecallWebView extends WebView {
 
     private Listener listener;
 
-    final static String version = "0.0.45";
+    final static String version = "0.0.46";
 
     private final static String[] defaultPagecallUrls = {"app.pagecall", "demo.pagecall", "192.168"};
     private final static String jsInterfaceName = "pagecallAndroidBridge";


### PR DESCRIPTION
In #68, support for detecting wired earphones was implemented, but an issue remained where earphones connected via a USB port (specifically devices with `AudioDeviceInfo.TYPE_USB_HEADSET`) were not being recognized.

Previously, the implementation used a whitelist approach to select specific earphone types. This has now been changed to a blacklist approach, where any device other than `TYPE_BUILTIN_SPEAKER` will be used as the active audio device. This adjustment allows for better handling of various types of connected devices.