### PR TITLE
Fix USB-C Earphone Issue on Android 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The `credentials` field is necessary for this purpose. The required permission i
 2. Add the dependency to your app's build.gradle file:
 ```gradle
 dependencies {
-    implementation 'com.pagecall:pagecall-android-sdk:0.0.47' // Recommended to use the latest
+    implementation 'com.pagecall:pagecall-android-sdk:0.0.48' // Recommended to use the latest
 }
 ```
 3. Sync your project with the Gradle files.

--- a/pagecall/build.gradle
+++ b/pagecall/build.gradle
@@ -14,7 +14,7 @@ android {
         consumerProguardFiles "consumer-rules.pro"
 
         versionCode 0
-        versionName "0.0.47" // Update `version` field of PagecallWebView as you change this
+        versionName "0.0.48" // Update `version` field of PagecallWebView as you change this
     }
 
     buildTypes {
@@ -44,7 +44,7 @@ ext {
     GITHUB_USER = "pagecall"
     GITHUB_REPO = "pagecall-android-sdk"
     GITHUB_PKG_NAME = "pagecall-android-sdk"
-    GITHUB_PKG_VERSION = "0.0.47"
+    GITHUB_PKG_VERSION = "0.0.48"
 }
 
 publishing {

--- a/pagecall/src/main/java/com/pagecall/PagecallWebView.java
+++ b/pagecall/src/main/java/com/pagecall/PagecallWebView.java
@@ -92,7 +92,6 @@ final public class PagecallWebView extends WebView {
     private NativeBridge nativeBridge = null;
 
     private Context context;
-    private Boolean isChime = false;
 
     public PagecallWebView(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -118,26 +117,6 @@ final public class PagecallWebView extends WebView {
     @Override
     public void setWebViewClient(WebViewClient client) {
         throw new UnsupportedOperationException("PagecallWebView does not support setWebViewClient");
-    }
-
-    public boolean handleVolumeKeys(int keyCode, KeyEvent event) {
-        if (!this.isChime) return false;
-        // chime일 때만 아래 코드를 실행
-        AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-        switch (keyCode) {
-            case KeyEvent.KEYCODE_VOLUME_UP:
-                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
-                        AudioManager.ADJUST_RAISE,
-                        AudioManager.FLAG_SHOW_UI);
-                return true;
-            case KeyEvent.KEYCODE_VOLUME_DOWN:
-                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
-                        AudioManager.ADJUST_LOWER,
-                        AudioManager.FLAG_SHOW_UI);
-                return true;
-            default:
-                return false;
-        }
     }
 
     public void setListener(Listener listener) {
@@ -307,9 +286,6 @@ final public class PagecallWebView extends WebView {
             switch (bridgeAction) {
                 case LOADED: {
                     this.listener.onLoaded();
-                    this.post(() -> this.evaluateJavascript("!!Pagecall.media.chimeSession$", value -> {
-                        this.isChime = "true".equals(value);
-                    }));
                     break;
                 }
                 case TERMINATED: {

--- a/pagecall/src/main/java/com/pagecall/PagecallWebView.java
+++ b/pagecall/src/main/java/com/pagecall/PagecallWebView.java
@@ -202,6 +202,7 @@ final public class PagecallWebView extends WebView {
         if (bluetoothDevice != null) {
             audioManager.startBluetoothSco();
             audioManager.setBluetoothScoOn(true);
+            audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 audioManager.setCommunicationDevice(bluetoothDevice);
             }
@@ -223,6 +224,7 @@ final public class PagecallWebView extends WebView {
         }
         if (externalDevice != null) {
             audioManager.setSpeakerphoneOn(false);
+            audioManager.setMode(AudioManager.MODE_NORMAL); // Using MODE_IN_COMMUNICATION routes to builtin speaker in Android 10
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 audioManager.setCommunicationDevice(externalDevice);
             }
@@ -235,6 +237,7 @@ final public class PagecallWebView extends WebView {
         // 3. Builtin
         AudioDeviceInfo builtinDevice = devices.get(0);
         audioManager.setSpeakerphoneOn(true);
+        audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             audioManager.clearCommunicationDevice();
         }
@@ -272,7 +275,6 @@ final public class PagecallWebView extends WebView {
 
 
         AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-        audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
         audioManager.registerAudioDeviceCallback(audioDeviceCallback, null);
 
         if (nativeBridge == null) nativeBridge = new NativeBridge(this, subscribers);
@@ -480,8 +482,9 @@ final public class PagecallWebView extends WebView {
         destroyBridge();
 
         AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-        audioManager.stopBluetoothSco();
         audioManager.unregisterAudioDeviceCallback(audioDeviceCallback);
+        audioManager.stopBluetoothSco();
+        audioManager.setMode(AudioManager.MODE_NORMAL);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             audioManager.clearCommunicationDevice();
         }

--- a/pagecall/src/main/java/com/pagecall/PagecallWebView.java
+++ b/pagecall/src/main/java/com/pagecall/PagecallWebView.java
@@ -82,7 +82,7 @@ final public class PagecallWebView extends WebView {
 
     private Listener listener;
 
-    final static String version = "0.0.47";
+    final static String version = "0.0.48";
 
     private final static String[] defaultPagecallUrls = {"app.pagecall", "demo.pagecall", "192.168"};
     private final static String jsInterfaceName = "pagecallAndroidBridge";

--- a/sample/src/main/java/com/pagecall/sample/MainActivity.java
+++ b/sample/src/main/java/com/pagecall/sample/MainActivity.java
@@ -27,15 +27,6 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    @Override
-    public boolean onKeyDown(int keyCode, KeyEvent event) {
-        PagecallFragment pagecallFragment = getPagecallFragment();
-        if (pagecallFragment != null && pagecallFragment.processKeyDown(keyCode, event)) {
-            return true;
-        }
-        return super.onKeyDown(keyCode, event);
-    }
-
     private PagecallFragment getPagecallFragment() {
         Fragment navHostFragment = getSupportFragmentManager().findFragmentById(R.id.nav_host_fragment_content_main);
         if (navHostFragment != null) {

--- a/sample/src/main/java/com/pagecall/sample/PagecallFragment.java
+++ b/sample/src/main/java/com/pagecall/sample/PagecallFragment.java
@@ -97,13 +97,6 @@ public class PagecallFragment extends Fragment implements PagecallWebView.Listen
         webView.onActivityResult(requestCode, resultCode, intent);
     }
 
-    public boolean processKeyDown(int keyCode, KeyEvent event) {
-        if (webView.handleVolumeKeys(keyCode, event)) {
-            return true;
-        }
-        return false;
-    }
-
     // PagecallWebView.Listener implementations
     @Override
     public void onLoadStateChange(String message) {


### PR DESCRIPTION
- Removed handlers which were deprecated as of #65
- Fixed an issue where audio output would default to the built-in speaker when connecting USB-C earphones on Android 10.

### Tests Conducted

- Verified proper audio transmission and reception on Android 10 using the built-in speaker, USB-C earphones, 3.5mm jack earphones, and Bluetooth earphones.
- Confirmed the same behavior on Android 13 across all mentioned devices.