### PR TITLE
Avoid premature pause state sync and ensure initial device logging after initialization

### DIFF
--- a/pagecall/src/main/java/com/pagecall/NativeBridge.java
+++ b/pagecall/src/main/java/com/pagecall/NativeBridge.java
@@ -234,7 +234,6 @@ class NativeBridge {
                     }
                     MediaInfraController.MiInitialPayload initialPayload = new MediaInfraController.MiInitialPayload(payloadData);
                     this.mediaController = new MediaInfraController(emitter, initialPayload, context);
-                    this.synchronizePauseState();
                     respondEmpty.accept(null);
                     return;
                 case GET_PERMISSIONS:

--- a/pagecall/src/main/java/com/pagecall/PagecallWebView.java
+++ b/pagecall/src/main/java/com/pagecall/PagecallWebView.java
@@ -289,6 +289,8 @@ final public class PagecallWebView extends WebView {
             switch (bridgeAction) {
                 case LOADED: {
                     this.listener.onLoaded();
+                    this.nativeBridge.log("initialDevice", "Triggering updateCommunicationDevice to log initial device");
+                    updateCommunicationDevice();
                     break;
                 }
                 case TERMINATED: {


### PR DESCRIPTION
`synchronizePauseState` is only meaningful when a producer exists. Previously, it was being called immediately after `initialize`, before `start`, at a point when the producer had not yet been created. This caused an unnecessary error log to appear, even though no actual error had occurred. This behavior has now been corrected.

Additionally, since the initial call to `updateCommunicationDevice` occurs before the web context is fully initialized, the corresponding log is not recorded. If the user doesn’t change their device after connecting, it becomes impossible to determine which device was used. To address this, the method is now called once again after initialization to ensure the device information is properly logged.