### PR TITLE
Resolve file upload crash in Flutter integration through safe context casting

### DIFF
--- a/pagecall/build.gradle
+++ b/pagecall/build.gradle
@@ -14,7 +14,7 @@ android {
         consumerProguardFiles "consumer-rules.pro"
 
         versionCode 0
-        versionName "0.0.50" // Update `version` field of PagecallWebView as you change this
+        versionName "0.0.51" // Update `version` field of PagecallWebView as you change this
     }
 
     buildTypes {
@@ -44,7 +44,7 @@ ext {
     GITHUB_USER = "pagecall"
     GITHUB_REPO = "pagecall-android-sdk"
     GITHUB_PKG_NAME = "pagecall-android-sdk"
-    GITHUB_PKG_VERSION = "0.0.50"
+    GITHUB_PKG_VERSION = "0.0.51"
 }
 
 publishing {

--- a/pagecall/src/main/java/com/pagecall/PagecallWebChromeClient.java
+++ b/pagecall/src/main/java/com/pagecall/PagecallWebChromeClient.java
@@ -46,7 +46,7 @@ public class PagecallWebChromeClient extends WebChromeClient {
         chooserIntent.putExtra(Intent.EXTRA_INTENT, fileSelectionIntent);
         chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, extraIntents.toArray(new Parcelable[]{}));
 
-        ((Activity) this.webView.getContext()).startActivityForResult(chooserIntent, IMAGE_SELECTOR_REQ);
+        this.webView.startActivityForResult(chooserIntent, IMAGE_SELECTOR_REQ);
 
         return true;
     }

--- a/pagecall/src/main/java/com/pagecall/PagecallWebView.java
+++ b/pagecall/src/main/java/com/pagecall/PagecallWebView.java
@@ -380,6 +380,21 @@ final public class PagecallWebView extends WebView {
         super.setWebChromeClient(this.webChromeClient);
     }
 
+    public void startActivityForResult(Intent intent, int requestCode) {
+        Context context = getContext();
+        if (context instanceof Activity) {
+            ((Activity) context).startActivityForResult(intent, requestCode);
+            return;
+        } else if (context instanceof MutableContextWrapper) {
+            Context baseContext = ((MutableContextWrapper) context).getBaseContext();
+            if (baseContext instanceof Activity) {
+                ((Activity) baseContext).startActivityForResult(intent, requestCode);
+                return;
+            }
+        }
+        Log.e("PagecallWebView", "activity cannot be started due to Unexpected context");
+    }
+
     public void onActivityResult(final int requestCode, final int resultCode, final Intent intent) {
         if (this.webChromeClient != null) {
             this.webChromeClient.handleActivityResult(requestCode, resultCode, intent);

--- a/pagecall/src/main/java/com/pagecall/PagecallWebView.java
+++ b/pagecall/src/main/java/com/pagecall/PagecallWebView.java
@@ -83,7 +83,7 @@ final public class PagecallWebView extends WebView {
 
     private Listener listener;
 
-    final static String version = "0.0.50";
+    final static String version = "0.0.51";
 
     private final static String[] defaultPagecallUrls = {"app.pagecall", "demo.pagecall", "192.168"};
     private final static String jsInterfaceName = "pagecallAndroidBridge";


### PR DESCRIPTION
Previously, the code assumed `webView.getContext()` could be directly cast to `Activity`, which caused crashes in Flutter environments where the context might be wrapped or of a different type. The new implementation safely handles different context types commonly found in Flutter integrations.