### PR TITLE
Update to 16KB page size support and modernize Android build

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,8 +4,9 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="11" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="corretto-11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '7.2.1' apply false
-    id 'com.android.library' version '7.2.1' apply false
+    id 'com.android.application' version '8.1.4' apply false
+    id 'com.android.library' version '8.1.4' apply false
 }
 
 task clean(type: Delete) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 03 19:38:17 KST 2023
+#Fri Oct 10 14:50:20 KST 2025
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/pagecall/build.gradle
+++ b/pagecall/build.gradle
@@ -30,6 +30,7 @@ android {
     }
 }
 
+
 dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.6.1'
@@ -38,7 +39,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
     api 'com.google.code.gson:gson:2.8.9'
-    api 'io.github.haiyangwu:mediasoup-client:3.4.0'
+    api 'com.pagecall:mediasoup-client-android:3.4.0'
 }
 
 ext {
@@ -117,7 +118,7 @@ publishing {
             url = uri("https://maven.pkg.github.com/$GITHUB_USER/$GITHUB_REPO")
             credentials {
                 username = GITHUB_USER
-                password = System.getenv("GITHUB_TOKEN") 
+                password = System.getenv("GITHUB_TOKEN")
             }
         }
     }

--- a/pagecall/build.gradle
+++ b/pagecall/build.gradle
@@ -4,11 +4,12 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    namespace 'com.pagecall'
+    compileSdk 34
 
     defaultConfig {
         minSdk 23
-        targetSdk 33
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/pagecall/src/main/AndroidManifest.xml
+++ b/pagecall/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.pagecall">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 </manifest>

--- a/pagecall/src/main/java/com/pagecall/AudioRecordManager.java
+++ b/pagecall/src/main/java/com/pagecall/AudioRecordManager.java
@@ -26,8 +26,8 @@ class AudioRecordManager {
 
     private static final int SAMPLE_RATE = 8000;
 
-    private static final double AMPLITUDE_IDLE = 1000.0;
-    private static final double AMPLITUDE_MAX = 10000.0;
+    private static final double AMPLITUDE_IDLE = 50.0;
+    private static final double AMPLITUDE_MAX = 1000.0;
 
     /**
      * Checks Permission, computes and returns amplitude in 0 ~ 10000
@@ -46,7 +46,7 @@ class AudioRecordManager {
             bufferSize = AudioRecord.getMinBufferSize(SAMPLE_RATE, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT);
             if (bufferSize != AudioRecord.ERROR_BAD_VALUE && bufferSize != AudioRecord.ERROR) {
                 buffer = new short[bufferSize];
-                audioRecord = new AudioRecord(MediaRecorder.AudioSource.MIC, SAMPLE_RATE, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT, bufferSize);
+                audioRecord = new AudioRecord(MediaRecorder.AudioSource.VOICE_COMMUNICATION, SAMPLE_RATE, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT, bufferSize);
             }
         }
 

--- a/pagecall/src/main/java/com/pagecall/AudioRecordManager.java
+++ b/pagecall/src/main/java/com/pagecall/AudioRecordManager.java
@@ -96,7 +96,7 @@ class AudioRecordManager {
      */
     static void startEmitVolumeSchedule(@NonNull Context context, @NonNull WebViewEmitter emitter) {
         if (volumeEmitter == null) volumeEmitter = Executors.newSingleThreadScheduledExecutor();
-        volumeEmitter.scheduleAtFixedRate(
+        volumeEmitter.scheduleWithFixedDelay(
                 () -> {
                     double volume = getMicrophoneVolume(context);
                     if (volume < 0) return;

--- a/pagecall/src/main/java/com/pagecall/AudioRecordManager.java
+++ b/pagecall/src/main/java/com/pagecall/AudioRecordManager.java
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeUnit;
  */
 class AudioRecordManager {
     private static AudioRecord audioRecord;
-    private static ScheduledExecutorService volumeEmitter;
 
     private static int bufferSize;
     private static short[] buffer;
@@ -80,40 +79,12 @@ class AudioRecordManager {
      * returns volume in 0 ~ 1
      *
      * @param context Android Context
-     * @return -1 if permission is not granted or it failed to get the volume
      */
     static double getMicrophoneVolume(@NonNull Context context) {
         double amplitude = getMicrophoneAmplitude(context);
         if (amplitude < 0) return amplitude;
         double volume = (amplitude - AMPLITUDE_IDLE) / AMPLITUDE_MAX;
         return Math.max(0, Math.min(1, volume));
-    }
-
-    /**
-     * emit microphone decibel every second
-     * @param context Android Context
-     * @param emitter
-     */
-    static void startEmitVolumeSchedule(@NonNull Context context, @NonNull WebViewEmitter emitter) {
-        if (volumeEmitter == null) volumeEmitter = Executors.newSingleThreadScheduledExecutor();
-        volumeEmitter.scheduleWithFixedDelay(
-                () -> {
-                    double volume = getMicrophoneVolume(context);
-                    if (volume < 0) return;
-                    emitter.emit(NativeBridgeEvent.AUDIO_VOLUME, Double.toString(volume));
-                },
-                0,
-                500,
-                TimeUnit.MILLISECONDS
-        );
-    }
-
-
-    static void shutdownSchedule() {
-        if (volumeEmitter != null) {
-            volumeEmitter.shutdown();
-            volumeEmitter = null;
-        }
     }
 
     static void dispose() {
@@ -128,6 +99,5 @@ class AudioRecordManager {
             audioRecord.release();
             audioRecord = null;
         }
-        shutdownSchedule();
     }
 }

--- a/pagecall/src/main/java/com/pagecall/NativeBridge.java
+++ b/pagecall/src/main/java/com/pagecall/NativeBridge.java
@@ -308,8 +308,6 @@ class NativeBridge {
                             }
                         });
                         this.synchronizePauseState();
-                        // emit decibel after entering
-                        AudioRecordManager.startEmitVolumeSchedule(context, emitter);
                     }
                     return;
                 case DISPOSE:

--- a/pagecall/src/main/java/com/pagecall/NativeBridge.java
+++ b/pagecall/src/main/java/com/pagecall/NativeBridge.java
@@ -23,18 +23,18 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 class NativeBridge {
-    private PagecallWebView pagecallWebView;
+    private final PagecallWebView pagecallWebView;
     private MediaController mediaController;
-    private Context context;
-    private WebViewEmitter emitter;
+    private final Context context;
+    private final WebViewEmitter emitter;
 
-    private HashMap<String, Consumer<String>> subscribers;
+    private final HashMap<String, Consumer<String>> subscribers;
 
     private Boolean isAudioPaused = false;
 
     public Boolean loaded = false;
 
-    private ArrayList<Consumer<JSONObject>> bridgeMessageConsumers = new ArrayList();
+    private final ArrayList<Consumer<JSONObject>> bridgeMessageConsumers = new ArrayList();
 
     public void listenBridgeMessages(Consumer<JSONObject> listener) {
         this.bridgeMessageConsumers.add(listener);
@@ -192,18 +192,9 @@ class NativeBridge {
 
         final BiConsumer<Exception, String> respond = (error, data) -> {
             if (error != null) {
-                if (requestId != null) {
-                    emitter.responseError(requestId, error.getLocalizedMessage());
-                } else {
-                    emitter.error("RequestFailed", error.getLocalizedMessage());
-                }
+                emitter.responseError(requestId, error.getLocalizedMessage());
             } else {
-                if (requestId != null) {
-                    emitter.response(requestId, data);
-                } else {
-                    System.out.println("Missing requestId");
-                    emitter.error("RequestIdMissing", action + " succeeded without requestId");
-                }
+                emitter.response(requestId, data);
             }
         };
         final BiConsumer<Exception, JSONObject> respondObject = (error, data) -> {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -31,6 +31,11 @@ android {
     buildFeatures {
         viewBinding true
     }
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging true
+        }
+    }
 }
 
 dependencies {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -4,12 +4,13 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    namespace 'com.pagecall.sample'
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.pagecall.sample"
         minSdk 23
-        targetSdk 33
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.pagecall.sample">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.CAMERA" />

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,14 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/pagecall/mediasoup-client-android")
+            credentials {
+                username = System.getenv("GITHUB_USERNAME")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
     }
 }
 rootProject.name = "PagecallAndroidSample"


### PR DESCRIPTION
- **16KB page size support**: Google recently enforced 16KB page sizes. The existing library didn't support this, so we forked it, published a new version, and updated the dependency to use our custom package.
- **Consistent volume detection**: Fixed an issue where volume detection worked before joining but failed after joining. This was caused by the audio mode switching from `MIC` to `VOICE_COMMUNICATION`. Improved volume detection by consistently tracking `VOICE_COMMUNICATION` throughout.
  - Remove automatic volume emission in favor of on-demand requests 
- Upgrade Android Gradle Plugin to 8.1.4 and Gradle to 8.5
- Update target SDK to 34 and Java target to 21
- Add JNI legacy packaging option for better compatibility