### PR TITLE
Revert volume consistency change causing audio feedback on some devices

### DIFF
--- a/pagecall/build.gradle
+++ b/pagecall/build.gradle
@@ -15,7 +15,7 @@ android {
         consumerProguardFiles "consumer-rules.pro"
 
         versionCode 0
-        versionName "0.0.51" // Update `version` field of PagecallWebView as you change this
+        versionName "0.0.53" // Update `version` field of PagecallWebView as you change this
     }
 
     buildTypes {
@@ -46,7 +46,7 @@ ext {
     GITHUB_USER = "pagecall"
     GITHUB_REPO = "pagecall-android-sdk"
     GITHUB_PKG_NAME = "pagecall-android-sdk"
-    GITHUB_PKG_VERSION = "0.0.52"
+    GITHUB_PKG_VERSION = "0.0.53"
 }
 
 publishing {

--- a/pagecall/src/main/java/com/pagecall/AudioRecordManager.java
+++ b/pagecall/src/main/java/com/pagecall/AudioRecordManager.java
@@ -26,8 +26,8 @@ class AudioRecordManager {
 
     private static final int SAMPLE_RATE = 8000;
 
-    private static final double AMPLITUDE_IDLE = 50.0;
-    private static final double AMPLITUDE_MAX = 1000.0;
+    private static final double AMPLITUDE_IDLE = 1000.0;
+    private static final double AMPLITUDE_MAX = 10000.0;
 
     /**
      * Checks Permission, computes and returns amplitude in 0 ~ 10000
@@ -46,7 +46,7 @@ class AudioRecordManager {
             bufferSize = AudioRecord.getMinBufferSize(SAMPLE_RATE, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT);
             if (bufferSize != AudioRecord.ERROR_BAD_VALUE && bufferSize != AudioRecord.ERROR) {
                 buffer = new short[bufferSize];
-                audioRecord = new AudioRecord(MediaRecorder.AudioSource.VOICE_COMMUNICATION, SAMPLE_RATE, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT, bufferSize);
+                audioRecord = new AudioRecord(MediaRecorder.AudioSource.MIC, SAMPLE_RATE, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT, bufferSize);
             }
         }
 

--- a/pagecall/src/main/java/com/pagecall/PagecallWebView.java
+++ b/pagecall/src/main/java/com/pagecall/PagecallWebView.java
@@ -83,7 +83,7 @@ final public class PagecallWebView extends WebView {
 
     private Listener listener;
 
-    final static String version = "0.0.52";
+    final static String version = "0.0.53";
 
     private final static String[] defaultPagecallUrls = {"app.pagecall", "demo.pagecall", "192.168"};
     private final static String jsInterfaceName = "pagecallAndroidBridge";


### PR DESCRIPTION
After deploying the volume consistency fix from PR #78 (commit b9bc228), we discovered that on certain Android devices (specifically SM-X200 running Android 12), the remote participant's audio was being fed back and retransmitted, creating an echo effect.
It reverted changes in `AudioRecordManager.java` to previous working state, and this temporarily removes the volume consistency fix to resolve the critical audio feedback issue.